### PR TITLE
Fixes unspecified region

### DIFF
--- a/anti_forgetful/instance.py
+++ b/anti_forgetful/instance.py
@@ -5,11 +5,12 @@ from .util import handle_cfg, run
 class SessionInstance:
     def __init__(self, cfg, instance_id = None, image_id = None):
         self.cfg = cfg
+        self.region = region
         self.image_id = image_id
         self.instance_id = instance_id
 
     def __enter__(self):
-        self.ec2_resource = boto3.resource('ec2')
+        self.ec2_resource = boto3.resource('ec2', self.region)
         if self.instance_id is None:
             self.create_instance()
             print('Creating instance: ', self.instance.id)

--- a/example/awscfg.py
+++ b/example/awscfg.py
@@ -1,6 +1,7 @@
 key_pair_name = 'tutorial_key_pair'
 group_name = 'tutorial_group'
 instance_type = 't2.micro'
+region = 'us-east-2'
 no_strict_host_checking = True
 
 base_image_id = 'ami-428aa838'


### PR DESCRIPTION
Add `region` field in the configuration file.

I'm not sure if you have any preferences here.  You could leave an empty string field and make a note in the `README.md` that the user needs to fill in prior to running.