### PR TITLE
Metric monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ instance_type = 't2.micro'
 # launching your instance.
 no_strict_host_checking = True
 
+# Metric monitoring will track the total amount of resources your instance has 
+# consumed.  This option is False by default, set to True, to monitor resource
+# usage
+metric_monitoring = False
+
 # The base image to build from. You probably shouldn't change this. 
 base_image_id = 'ami-428aa838'
 

--- a/anti_forgetful/instance.py
+++ b/anti_forgetful/instance.py
@@ -19,8 +19,9 @@ class SessionInstance:
             print('Starting instance: ', self.instance.id)
         try:
             print('Waiting for instance to boot up')
-            self.metric_monitor = MetricMonitor(self.instance_id)
-            self.metric_monitor.start()
+            if self.cfg.metric_monitoring:
+                self.metric_monitor = MetricMonitor(self.instance_id)
+                self.metric_monitor.start()
             self.instance.wait_until_running()
             self.instance.reload()
             self.wait_until_ssh_accessible()

--- a/anti_forgetful/instance.py
+++ b/anti_forgetful/instance.py
@@ -1,6 +1,7 @@
-import time
 import boto3
 from .util import handle_cfg, run
+from .metrics import MetricMonitor, Metric, NetworkIn
+
 
 class SessionInstance:
     def __init__(self, cfg, instance_id = None, image_id = None):
@@ -18,6 +19,8 @@ class SessionInstance:
             print('Starting instance: ', self.instance.id)
         try:
             print('Waiting for instance to boot up')
+            self.metric_monitor = MetricMonitor(self.instance_id)
+            self.metric_monitor.start()
             self.instance.wait_until_running()
             self.instance.reload()
             self.wait_until_ssh_accessible()
@@ -46,6 +49,7 @@ class SessionInstance:
                 'Tags': [{'Key': 'Name', 'Value': self.cfg.instance_name}]
             }],
         )[0]
+        self.instance_id = self.instance.id
 
     def wait_until_ssh_accessible(self):
         while self.run_cmd('echo "Checking if instance is up and running"') != 0:
@@ -61,6 +65,7 @@ class SessionInstance:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         print('Stopping instance...')
+        self.metric_monitor.instance_up = False
         self.instance.stop()
 
     def run_cmd(self, remote_cmd):

--- a/anti_forgetful/launch.py
+++ b/anti_forgetful/launch.py
@@ -2,6 +2,7 @@ import boto3
 from botocore.exceptions import ClientError
 from .instance import SessionInstance
 from .util import handle_cfg
+import os
 
 def main():
     cfg = handle_cfg()
@@ -43,6 +44,7 @@ def create_key_pair(key_pair_name):
         filename = key_pair_name + '.pem'
         print('saving ' + key_pair_name + ' to ' + filename)
         open(filename, 'w').write(response.key_material)
+        os.chmod(filename, 0o600)
     except ClientError as e:
         print(e)
 

--- a/anti_forgetful/metrics.py
+++ b/anti_forgetful/metrics.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import boto3
+from datetime import datetime, timezone
+from functools import partial
+from threading import Thread
+from time import sleep
+
+
+class Metric(dict):
+
+    def __init__(self, instance_id, start):
+        super().__init__()
+        self.instance_id = instance_id
+        self.start = start
+        self['Namespace']  = 'AWS/EC2'
+        self['Unit']      = 'Bytes'
+        self['Statistics'] = ['Sum']
+        self['Dimensions'] = [{'Name':'InstanceId', 
+                               'Value':self.instance_id}]
+        self['StartTime']  = self.start
+        self['EndTime']    = None 
+        self['Period']     = None
+        self['MetricName'] = None
+
+    @property
+    def set_period(self):
+        now = datetime.now(tz=timezone.utc)
+        self['EndTime'] = now
+        period = (now - self.start).seconds
+        period -= (period % 60)
+        self['Period'] = period
+
+class NetworkIn(Metric):
+
+    def __init__(self, cloud_watch, instance_id, start, unit='Bytes'):
+        super().__init__(instance_id, start)
+        self.cloud_watch = cloud_watch
+        self['MetricName'] = 'NetworkIn'
+        self['Unit'] = unit
+        self.get_metrics = partial(self.cloud_watch.get_metric_statistics,
+                                   Namespace=self['Namespace'],
+                                   MetricName=self['MetricName'],
+                                   Dimensions=self['Dimensions'],
+                                   StartTime=self['StartTime'],
+                                   Statistics=self['Statistics'],
+                                   Unit=self['Unit'])
+        
+    def request_statistics(self):
+        self.set_period
+        self.metric_statistics = self.get_metrics(EndTime=self['EndTime'], 
+                                                  Period=self['Period'])
+
+    def __str__(self):
+        return str(self.metric_statistics)
+
+class MetricMonitor(Thread):
+
+    def __init__(self, instance_id):
+        super().__init__()
+        self.interval = 300 # 5-min intervals
+        self.instance_up = True
+        self.instance_id = instance_id
+        self.cloud_watch = boto3.client('cloudwatch')
+        self.ec2_client = boto3.client('ec2')
+        self.metrics = [NetworkIn]
+
+    def run(self):
+        instance_description = self.ec2_client.describe_instances(InstanceIds=[self.instance_id])
+        start = instance_description['Reservations'][0]['Instances'][0]['LaunchTime']
+        self.metrics = [metric(self.cloud_watch, self.instance_id, start) for metric in self.metrics]
+        while self.instance_up:
+            sleep(self.interval)
+            for metric in self.metrics:
+                metric.request_statistics()
+                print(metric)

--- a/example/awscfg.py
+++ b/example/awscfg.py
@@ -2,6 +2,7 @@ key_pair_name = 'tutorial_key_pair'
 group_name = 'tutorial_group'
 instance_type = 't2.micro'
 no_strict_host_checking = True
+metric_monitoring = False
 
 base_image_id = 'ami-428aa838'
 root_volume_size = 30 # In GB


### PR DESCRIPTION
This doesn't have much polish to it but gives the general idea of the functionality I brought up in #4 .

There could be a metric for each of the basic aws tiers available in the same form as `NetworkIn` class.  Adding in the capability for callbacks from here isn't too far off, which leads into stopping instances, scaling, migrating, os-level adjustments etc. if limits/markers are reached.

